### PR TITLE
Add modeler username and email address

### DIFF
--- a/contracts/Choreography.sol
+++ b/contracts/Choreography.sol
@@ -43,33 +43,33 @@ contract Choreography {
         _;
     }
 
-    modifier requireVerifier(address sender) {
-        require(verifiers.has(sender) == true, "You are not a verifier.");
+    modifier requireVerifier(address _sender) {
+        require(verifiers.has(_sender) == true, "You are not a verifier.");
         _;
     }
 
-    modifier requireReviewer(address sender) {
-        require(reviewers.has(sender) == true, "You are not a reviewer.");
+    modifier requireReviewer(address _sender) {
+        require(reviewers.has(_sender) == true, "You are not a reviewer.");
         _;
     }
 
-    modifier requireModeler(address sender) {
-        require(modelers.isRegistered(sender) == true, "You are not a modeler in this diagram.");
+    modifier requireModeler(address _sender) {
+        require(modelers.isRegistered(_sender) == true, "You are not a modeler in this diagram.");
         _;
     }
 
-    constructor(string username, string email)
+    constructor(string _username, string _email)
         public
     {
-        modelers.add(msg.sender, username, email);
+        modelers.add(msg.sender, _username, _email);
     }
 
-    function addModeler(address modeler, string username, string email)
+    function addModeler(address _modeler, string _username, string _email)
         external
         requireModeler(msg.sender)
         returns (bool)
     {
-        return modelers.add(modeler, username, email);
+        return modelers.add(_modeler, _username, _email);
     }
 
     // SUBMISSION PHASE
@@ -86,13 +86,12 @@ contract Choreography {
         state = States.SET_REVIEWERS;
     }
 
-    function addReviewer(address reviewer)
+    function addReviewer(address _reviewer)
         external
         isInState(States.SET_REVIEWERS)
         requireProposer(msg.sender)
     {
-        // Add reviewer to list of required reviewers
-        reviewers.add(reviewer);
+        reviewers.add(_reviewer);
     }
 
     // VERIFICATION PHASE

--- a/contracts/Choreography.sol
+++ b/contracts/Choreography.sol
@@ -72,6 +72,15 @@ contract Choreography {
         return modelers.add(_modeler, _username, _email);
     }
 
+    function getModelerInformation(address _modeler)
+        external
+        view
+        requireModeler(_modeler)
+        returns (string, string)
+    {
+        return modelers.getInformation(_modeler);
+    }
+
     // SUBMISSION PHASE
     function proposeChange(string _diff)
         external

--- a/contracts/Choreography.sol
+++ b/contracts/Choreography.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.4.24;
 
 import "./Roles.sol";
-import "./Arrays.sol";
+import "./Persons.sol";
 
 contract Choreography {
 
     using Roles for Roles.Role;
-    using Arrays for Arrays.Address;
+    using Persons for Persons.Person;
 
     enum States {
         READY,                 // 0 (default) | Aenderungsset kann gepushed werden
@@ -22,7 +22,7 @@ contract Choreography {
     bytes32 public id;
     Roles.Role private reviewers;
     Roles.Role private verifiers;
-    Arrays.Address private modelers;
+    Persons.Person private modelers;
     address public proposer;
     uint16 internal change_number = 0;
     uint public timestamp;
@@ -54,14 +54,14 @@ contract Choreography {
     }
 
     modifier requireModeler(address sender) {
-        require(modelers.contains(sender) == true, "You are not a modeler in this diagram.");
+        require(modelers.isRegistered(sender) == true, "You are not a modeler in this diagram.");
         _;
     }
 
     constructor()
         public
     {
-        modelers.push(msg.sender);
+        modelers.add(msg.sender, "testuser", "test@choreo.org");
     }
 
     function addModeler(address modeler)
@@ -69,7 +69,7 @@ contract Choreography {
         requireModeler(msg.sender)
         returns (bool)
     {
-        return modelers.pushUnique(modeler);
+        return modelers.add(modeler, "testuser", "test@choreo.org");
     }
 
     // SUBMISSION PHASE
@@ -103,9 +103,7 @@ contract Choreography {
     {
         state = States.WAIT_FOR_VERIFIERS;
         // TODO Implement logic for assigning verifiers
-        for (uint ii = 0; ii <= modelers.getLength() / 2; ii++) {
-            verifiers.add(modelers.get(ii));
-        }
+        verifiers.add(proposer);
     }
 
     function approveReviewers()

--- a/contracts/Choreography.sol
+++ b/contracts/Choreography.sol
@@ -58,18 +58,18 @@ contract Choreography {
         _;
     }
 
-    constructor()
+    constructor(string username, string email)
         public
     {
-        modelers.add(msg.sender, "testuser", "test@choreo.org");
+        modelers.add(msg.sender, username, email);
     }
 
-    function addModeler(address modeler)
+    function addModeler(address modeler, string username, string email)
         external
         requireModeler(msg.sender)
         returns (bool)
     {
-        return modelers.add(modeler, "testuser", "test@choreo.org");
+        return modelers.add(modeler, username, email);
     }
 
     // SUBMISSION PHASE

--- a/contracts/Choreography.sol
+++ b/contracts/Choreography.sol
@@ -72,13 +72,22 @@ contract Choreography {
         return modelers.add(_modeler, _username, _email);
     }
 
-    function getModelerInformation(address _modeler)
+    function getModelerUsername(address _modeler)
         external
         view
         requireModeler(_modeler)
-        returns (string, string)
+        returns (string)
     {
-        return modelers.getInformation(_modeler);
+        return modelers.getUsername(_modeler);
+    }
+
+    function getModelerEmail(address _modeler)
+        external
+        view
+        requireModeler(_modeler)
+        returns (string)
+    {
+        return modelers.getEmailAddress(_modeler);
     }
 
     // SUBMISSION PHASE

--- a/contracts/Persons.sol
+++ b/contracts/Persons.sol
@@ -1,0 +1,70 @@
+pragma solidity ^0.4.24;
+
+import "./Arrays.sol";
+
+library Persons {
+
+    using Arrays for Arrays.Address;
+
+    struct Information {
+        string username;
+        string emailAddress;
+    }
+
+    struct Person {
+        mapping (address => Information) personalInformation;
+        Arrays.Address persons;
+    }
+
+    function add(Person storage _person, address _account, string _username, string _email)
+        internal
+    {
+        _person.persons.pushUnique(_account);
+        _person.personalInformation[_account] = Information(_username, _email);
+    }
+
+    function remove(Person storage _person, address _account)
+        internal
+    {
+        _person.persons.remove(_account);
+    }
+
+    function isRegisteredPerson(Person storage _person, address _account)
+        internal
+        view
+        returns (bool)
+    {
+        return _person.persons.contains(_account);
+    }
+
+    function getInformation(Person storage _person, address _account)
+        internal
+        view
+        returns (string, string)
+    {
+        return (getUsername(_person, _account), getEmailAddress(_person, _account));
+    }
+
+    function getUsername(Person storage _person, address _account)
+        internal
+        view
+        returns (string)
+    {
+        return _person.personalInformation[_account].username;
+    }
+
+    function getEmailAddress(Person storage _person, address _account)
+        internal
+        view
+        returns (string)
+    {
+        return _person.personalInformation[_account].emailAddress;
+    }
+
+    function reset(Person storage _person)
+        internal
+    {
+        _person.persons.removeAll();
+    }
+
+}

--- a/contracts/Persons.sol
+++ b/contracts/Persons.sol
@@ -18,9 +18,14 @@ library Persons {
 
     function add(Person storage _person, address _account, string _username, string _email)
         internal
+        returns (bool)
     {
-        _person.persons.pushUnique(_account);
-        _person.personalInformation[_account] = Information(_username, _email);
+        if (_person.persons.pushUnique(_account))
+        {
+            _person.personalInformation[_account] = Information(_username, _email);
+            return true;
+        }
+        return false;
     }
 
     function remove(Person storage _person, address _account)

--- a/contracts/Persons.sol
+++ b/contracts/Persons.sol
@@ -34,7 +34,7 @@ library Persons {
         _person.persons.remove(_account);
     }
 
-    function isRegisteredPerson(Person storage _person, address _account)
+    function isRegistered(Person storage _person, address _account)
         internal
         view
         returns (bool)
@@ -70,6 +70,13 @@ library Persons {
         internal
     {
         _person.persons.removeAll();
+    }
+
+    function getNumberOfPersons(Person storage _person)
+        internal
+        view
+    {
+        _person.persons.getLength();
     }
 
 }

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -112,36 +112,3 @@ library Roles {
     }
 
 }
-
-
-/*
-
-BASED ON
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Smart Contract Solutions, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/access/Roles.sol
-https://openzeppelin.org/api/docs/learn-about-access-control.html
-
-*/

--- a/src/contract-interfaces/IChoreography.ts
+++ b/src/contract-interfaces/IChoreography.ts
@@ -10,8 +10,6 @@ export enum States {
 
 export default interface IChoreography {
   address: string;
-  username: string;
-  email: string;
 
   // getter
   state(): Promise<States>;
@@ -23,6 +21,7 @@ export default interface IChoreography {
   getModelerEmail(address: string): Promise<string>;
 
   // public functions
+  constructor(username: string, email: string);
   addModeler(address: string, username: string, email: string): Promise<boolean>;
   proposeChange(diff: string): Promise<void>;
   addReviewer(address: string): Promise<void>;

--- a/src/contract-interfaces/IChoreography.ts
+++ b/src/contract-interfaces/IChoreography.ts
@@ -10,6 +10,8 @@ export enum States {
 
 export default interface IChoreography {
   address: string;
+  username: string;
+  email: string;
 
   // getter
   state(): Promise<States>;
@@ -17,9 +19,11 @@ export default interface IChoreography {
   proposer(): Promise<string>;
   id(): Promise<BigNumber.BigNumber>;
   timestamp(): Promise<number>;
+  getModelerUsername(address: string): Promise<string>;
+  getModelerEmail(address: string): Promise<string>;
 
   // public functions
-  addModeler(address: string): Promise<boolean>;
+  addModeler(address: string, username: string, email: string): Promise<boolean>;
   proposeChange(diff: string): Promise<void>;
   addReviewer(address: string): Promise<void>;
   startVerification(): Promise<void>;


### PR DESCRIPTION
This PR adds an username and an email address to each modeler.
By this, logical changes are introduced:
 - If a new contract/model is deployed, the sender is added as the first, registered modeler. The contract constructor now takes an username and an email address for the sender too.
 - Each participant must now be added by an already registered modeler by calling `addModeler`. This function requires an username and an email address in addition to the address.
 - New external functions allow to retrieve usernames and email addresses for provided addresses.

Implements #5.