### PR TITLE
Use some default values when migrating / deploying the contracts

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -7,5 +7,5 @@ module.exports = function(deployer) {
   deployer.deploy(Roles);
   deployer.link(Arrays, Choreography);
   deployer.link(Roles, Choreography);
-  deployer.deploy(Choreography);
+  deployer.deploy(Choreography, "deployer", "deployer@truffle.example.org");
 };


### PR DESCRIPTION
Now, `truffle migrate` can be used again.
The _Choreography_ contract will be deployed with a _deployer_ user name.